### PR TITLE
Redis removal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       - ./debugging_imgs:/app/debugging_imgs
     environment:
       - DATABASE_URL
-      - REDIS_URL
       - MEDIA_DIR
       - NUMBA_DEBUG=0
     env_file:
@@ -104,7 +103,6 @@ services:
 
 volumes:
   postgres_data: # Define a persistent volume for the PostgreSQL database (to outlive container restarts)
-  redis_data: # Persistent volume for the Redis cache
 
 networks:
   vinyl-network:


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file, specifically removing configurations related to Redis.

Configuration changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L38): Removed the `REDIS_URL` environment variable from the `services` section.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L107): Removed the `redis_data` persistent volume definition.